### PR TITLE
fix: support `PQ_LIB_DIR` env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ Building
 This repository contains direct, one-to-one mappings to the C functions provided
 in `libpq-fe.h` and `postgres_ext.h`. This library expects that libpq be
 installed on the system.
+
+You may need to specify the environment variable `LIB_PQ_DIR` to the location of
+your postgresql lib directory if the build fails.
+
+For OSX 10.11 you can use brew to install postgresql and then set the
+environment variable as described below:
+
+```
+brew install openssl
+export PQ_LIB_DIR=`brew --prefix postgresql`/lib
+```

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,15 @@
 use std::process::Command;
+use std::env;
 
 fn main() {
-    for output in Command::new("pg_config").arg("--libdir").output() {
-        if output.status.success() {
-            for path in String::from_utf8(output.stdout) {
-                println!("cargo:rustc-link-search=native={}", &path);
+    if let Ok(lib_dir) = env::var("PQ_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+    } else {
+        for output in Command::new("pg_config").arg("--libdir").output() {
+            if output.status.success() {
+                for path in String::from_utf8(output.stdout) {
+                    println!("cargo:rustc-link-search=native={}", &path);
+                }
             }
         }
     }


### PR DESCRIPTION
Setting the environment variable seems to reduce any potential breakage for others relying on the existing behavior. For mac, anyone using homebrew will have to make a change anyway once they move to beta and later.

Fix #1 