### PR TITLE
Static linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pq-sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 description = "Auto-generated rust bindings for libpq"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ installed on the system.
 You may need to specify the environment variable `LIB_PQ_DIR` to the location of
 your postgresql lib directory if the build fails.
 
+The build script instructs Cargo to link the library statically if the environmental
+variable `LIB_PQ_STATIC` is set. This can be useful, if targeting for a musl target.
+
 For OSX 10.11 you can use brew to install postgresql and then set the
 environment variable as described below:
 

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,15 @@ fn main() {
         let path = follow_dylib_symlinks(path.trim().into());
         println!("cargo:rustc-link-search=native={}", &path.display());
     }
+
+    let mode = if env::var_os("PQ_LIB_STATIC").is_some() {
+        "static"
+    } else {
+        "dylib"
+    };
+    let lib = "pq";
+    
+    println!("cargo:rustc-link-lib={}={}", mode, lib);
 }
 
 fn pg_config_output() -> Option<String> {


### PR DESCRIPTION
I tried to do a Diesel-based statically linked project, and managed to do that, but pq-sys needed a slight modification to be able to tell Cargo that static linking is requested. The way to do that is same as with the openssl-sys crate: it checks if an environmental variable (PQ_LIB_STATIC) is set, and prints out "cargo:rustc-link-lib=static=pq" or "cargo:rustc-link-lib=dylib=pq" based on that.

Should there be a release for 0.2.4?