### PR TITLE
Change default lib name to link on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 description = "Auto-generated rust bindings for libpq"
 license = "MIT"
 repository = "https://github.com/sgrif/pq-sys"
-links = "pq"
 build = "build.rs"
 
 [lib]

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,11 @@ fn main() {
     } else {
         "dylib"
     };
-    let lib = "pq";
+    let lib = if cfg!(target_os = "windows") {
+        "libpq"
+    } else {
+        "pq"
+    };
     
     println!("cargo:rustc-link-lib={}={}", mode, lib);
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::env;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ impl ::std::default::Default for Struct_pgresAttDesc {
 pub type PGresAttDesc = Struct_pgresAttDesc;
 pub type pgthreadlock_t =
     ::std::option::Option<extern "C" fn(acquire: ::libc::c_int) -> ()>;
-#[link(name = "pq")]
+
 extern "C" {
     pub fn PQconnectStart(conninfo: *const ::libc::c_char) -> *mut PGconn;
     pub fn PQconnectStartParams(keywords: *const *const ::libc::c_char,


### PR DESCRIPTION
On PostgresSQL's official download page here:
https://www.postgresql.org/download/windows/

There are two variants: EnterpriseDB and BigSQL
I tested both on my computer.
In EnterpriseDB's zip archive, there is no pq.lib but a libpq.lib.
There is no client library included in BigSQL's package.
So I think libpq.lib should be the default lib name to link.

Related issues:
https://github.com/sgrif/pq-sys/issues/3
https://github.com/diesel-rs/diesel/issues/487

Thanks.