### PR TITLE
Updating readme with correct env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ installed on the system.
 The build script of crate will attempt to find the lib path of libpq using the
 following methods:
 
-* First, if the environment variable `LIB_PQ_DIR` is set, it will use its value
+* First, if the environment variable `PQ_LIB_DIR` is set, it will use its value
 * If the environment variable isn't set, it tries to use pkg-config to locate it.
 All the config options, such as `PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_ALL_STATIC`
 etc., of the crate [pkg-config](http://alexcrichton.com/pkg-config-rs/pkg_config/index.html)


### PR DESCRIPTION
The environment variable listed in the README does not match the one that `build.rs` actually reads.