### PR TITLE
enable using libpq from the vcpkg ports tree for msvc abi builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+sudo: false
+script:
+  - rustc -V
+  - cargo -V
+  - cargo test
+os:
+  - linux
+  - osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ name = "pq_sys"
 
 [build-dependencies]
 pkg-config = { version = "0.3.0", optional = true }
+
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ following methods:
 All the config options, such as `PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_ALL_STATIC`
 etc., of the crate [pkg-config](http://alexcrichton.com/pkg-config-rs/pkg_config/index.html)
 apply.
+* For MSVC ABI builds the build script will attempt use the library from a 
+[vcpkg](https://github.com/Microsoft/vcpkg) installation if there is one available.
+You may need to set VCPKG_ROOT (or run `vcpkg integrate install`) and run
+`vcpkg install libpq:x64-windows`.
 * If it still can't locate the library, it will invoke the Postgres command
 `pg_config --libdir`
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+    VCPKG_DEFAULT_TRIPLET: x64-windows-static
+    RUSTFLAGS: -Ctarget-feature=+crt-static
+  - TARGET: x86_64-pc-windows-msvc
+    VCPKG_ALL_DYNAMIC: 1
+    VCPKG_DEFAULT_TRIPLET: x64-windows
+install:
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - if defined MSYS_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin
+  - rustc -V
+  - cargo -V
+  - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
+  - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install libpq
+
+build: false
+
+test_script:
+  - cargo test --target %TARGET%

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,7 @@
+extern crate pq_sys;
+
+#[test]
+fn test_ssl_init()
+{
+    unsafe{pq_sys::PQinitSSL(1);}
+}


### PR DESCRIPTION
This is with a view to enabling more easy `cargo install` of Diesel on windows.  [Vcpkg](https://github.com/Microsoft/vcpkg) is a newish Microsoft maintained collection of packages, like a ports tree or brew.

There is a script [here](https://github.com/mcgoo/vcpkg_diesel_build) that demonstrates building a totally static diesel.exe with Postgres and Sqlite. Mysql support is possible too but I don't have it working yet. Its more or less:

```
vcpkg install libpq:x64-windows-static sqlite3:x64-windows-static
set RUSTFLAGS=-Ctarget-feature=+crt-static
cargo install diesel_cli --no-default-features --features="postgres sqlite"
```

