### PR TITLE
allow using libpq configured without ssl in vcpkg

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
     VCPKG_DEFAULT_TRIPLET: x64-windows-static
     RUSTFLAGS: -Ctarget-feature=+crt-static
   - TARGET: x86_64-pc-windows-msvc
-    VCPKG_ALL_DYNAMIC: 1
+    VCPKGRS_DYNAMIC: 1
     VCPKG_DEFAULT_TRIPLET: x64-windows
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"

--- a/build.rs
+++ b/build.rs
@@ -42,12 +42,11 @@ fn configured_by_pkg_config() -> bool {
 fn configured_by_vcpkg() -> bool {
     vcpkg::probe_package("libpq").map(|_| {
 
-        // found libpq which depends on openssl and zlib
+        // found libpq which depends on openssl
         vcpkg::Config::new()
             .lib_name("libeay32")
             .lib_name("ssleay32")
-            .probe("openssl").expect("configured libpq from vcpkg but could not \
-                                        find openssl libraries that it depends on");
+            .probe("openssl").ok();
 
         println!("cargo:rustc-link-lib=crypt32");
         println!("cargo:rustc-link-lib=gdi32");


### PR DESCRIPTION
This is a minor tweak to the lib finding that reflects some experience gained from curl-sys.

Could you please publish a build of pg-sys and msqlclient-sys to crates.io when you get a moment?