### PR TITLE
Remove double colon in cargo::rerun-if-env-changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -129,7 +129,7 @@ fn configured_by_vcpkg() -> bool {
 fn pg_config_path() -> PathBuf {
     if let Ok(target) = env::var("TARGET") {
         let pg_config_for_target = &format!("PG_CONFIG_{}", target.to_ascii_uppercase().replace("-", "_"));
-        println!("cargo::rerun-if-env-changed={}", pg_config_for_target);
+        println!("cargo:rerun-if-env-changed={}", pg_config_for_target);
         if let Some(pg_config_path) = env::var_os(pg_config_for_target) {
 
             let path =  PathBuf::from(&pg_config_path);


### PR DESCRIPTION
s/cargo::rerun-if-env-changed/cargo:rerun-if-env-changed/

That broke my build with carnix (nixos) and probably does not work as intended elsewhere?

To allow others to find this bug by parts of the erro rmessage, this is the error I get for `buildRustCrate`:

```
building '/nix/store/hvkgqjc3fxikdizzh24y30n09gasz7q1-rust_diesel-1.3.2.drv'...
unpacking sources
unpacking source archive /nix/store/3ldkz3121m662zq3j5xmxd3wv1h222l3-diesel-1.3.2.tar.gz
source root is diesel-1.3.2.tar.gz
patching sources
configuring
/nix/store/br2k2fxkdzgv2d93xnrkd2kzbzd950yb-rust_pq-sys-0.4.5/env: line 1: export: `DEP_PQ_:RERUN-IF-ENV-CHANGED=PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU': not a valid identifier
builder for '/nix/store/hvkgqjc3fxikdizzh24y30n09gasz7q1-rust_diesel-1.3.2.drv' failed with exit code 1
cannot build derivation '/nix/store/91l9rpjf65j9gf0r55nr6qkgibmksvka-rust_we_api-0.1.0.drv': 1 dependencies couldn't be built
```