### PR TITLE
use vcpkg with automatic dependency following

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ name = "pq_sys"
 pkg-config = { version = "0.3.0", optional = true }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
-vcpkg = "0.2"
+vcpkg = "0.2.6"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ following methods:
 * First, if the environment variable `PQ_LIB_DIR` is set, it will use its value
 * If the environment variable isn't set, it tries to use pkg-config to locate it.
 All the config options, such as `PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_ALL_STATIC`
-etc., of the crate [pkg-config](http://alexcrichton.com/pkg-config-rs/pkg_config/index.html)
+etc., of the crate [pkg-config](https://docs.rs/pkg-config/)
 apply.
 * Then, for MSVC ABI builds the build script will attempt use the library from a
 [vcpkg](https://github.com/Microsoft/vcpkg) installation if there is one available.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ following methods:
 All the config options, such as `PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_ALL_STATIC`
 etc., of the crate [pkg-config](http://alexcrichton.com/pkg-config-rs/pkg_config/index.html)
 apply.
-* For MSVC ABI builds the build script will attempt use the library from a 
+* Then, for MSVC ABI builds the build script will attempt use the library from a
 [vcpkg](https://github.com/Microsoft/vcpkg) installation if there is one available.
-You may need to set VCPKG_ROOT (or run `vcpkg integrate install`) and run
-`vcpkg install libpq:x64-windows`.
+You may need to set VCPKG_ROOT (or run `vcpkg integrate install`), set VCPKGRS_DYNAMIC=1, and run
+`vcpkg install libpq:x64-windows`. See the documentation for the [vcpkg](https://docs.rs/vcpkg/) crate for more.
 * If it still can't locate the library, it will invoke the Postgres command
 `pg_config --libdir`
 

--- a/build.rs
+++ b/build.rs
@@ -106,18 +106,12 @@ fn configured_by_pkg_config() -> bool {
 
 #[cfg(target_env = "msvc")]
 fn configured_by_vcpkg() -> bool {
-    vcpkg::probe_package("libpq").map(|_| {
-
-        // found libpq which depends on openssl
-        vcpkg::Config::new()
-            .lib_name("libeay32")
-            .lib_name("ssleay32")
-            .probe("openssl").ok();
-
+    vcpkg::find_package("libpq").map(|_| {
         println!("cargo:rustc-link-lib=crypt32");
         println!("cargo:rustc-link-lib=gdi32");
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=secur32");
+        println!("cargo:rustc-link-lib=shell32");
     }).is_ok()
 }
 


### PR DESCRIPTION
This uses a more resilient api in the vcpkg crate to link recursively against all required ports in the vcpkg tree given the `libpq` port name.

This does not extend to knowing which system libraries are required. This now includes `shell32`, so it is added to the manual list of system libraries that are linked if `libpq` is found in vcpkg.