### PR TITLE
shell32 is neeeded in latest Rust builds because of linking errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -118,6 +118,7 @@ fn configured_by_vcpkg() -> bool {
         println!("cargo:rustc-link-lib=gdi32");
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=secur32");
+        println!("cargo:rustc-link-lib=shell32");
     }).is_ok()
 }
 


### PR DESCRIPTION
libpq.lib(fe-connect.c.obj) : error LNK2019: unresolved external symbol
__imp_SHGetFolderPathA referenced in function getPgPassFilename

closes issue #24 