### PR TITLE
Make cross-compilation possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The build script of crate will attempt to find the lib path of libpq using the
 following methods:
 
 * First, if the environment variable `PQ_LIB_DIR` is set, it will use its value
+* Second it will look for an environment variable in the format of `PQ_LIB_DIR_{TARGET}`
+where `{TARGET}` gets replaced by the Target environment variable set for cross-compilation
 * If the environment variable isn't set, it tries to use pkg-config to locate it.
 All the config options, such as `PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_ALL_STATIC`
 etc., of the crate [pkg-config](http://alexcrichton.com/pkg-config-rs/pkg_config/index.html)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ installed on the system.
 The build script of crate will attempt to find the lib path of libpq using the
 following methods:
 
-* First, if the environment variable `PQ_LIB_DIR` is set, it will use its value
-* Second it will look for an environment variable in the format of `PQ_LIB_DIR_{TARGET}`
+* First it will look for an environment variable in the format of `PQ_LIB_DIR_{TARGET}`
 where `{TARGET}` gets replaced by the Target environment variable set for cross-compilation
+* Second, if the environment variable `PQ_LIB_DIR` is set, it will use its value
 * If the environment variable isn't set, it tries to use pkg-config to locate it.
 All the config options, such as `PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_ALL_STATIC`
 etc., of the crate [pkg-config](http://alexcrichton.com/pkg-config-rs/pkg_config/index.html)

--- a/build.rs
+++ b/build.rs
@@ -141,6 +141,7 @@ fn configured_by_vcpkg() -> bool {
         println!("cargo:rustc-link-lib=gdi32");
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=secur32");
+        println!("cargo:rustc-link-lib=shell32");
     }).is_ok()
 }
 

--- a/build.rs
+++ b/build.rs
@@ -93,15 +93,11 @@ fn main() {
             Ok(pg_lib_path)
         }
         else{
-            println!("cargo:rerun-if-env-changed=PQ_LIB_DIR");
-            println!("PQ_LIB_DIR = {:?}", env::var("PQ_LIB_DIR"));
-            env::var("PQ_LIB_DIR")
+            use_general_lib_dir()
         }
     }
     else{
-        println!("cargo:rerun-if-env-changed=PQ_LIB_DIR");
-        println!("PQ_LIB_DIR = {:?}", env::var("PQ_LIB_DIR"));
-        env::var("PQ_LIB_DIR")
+        use_general_lib_dir()
     };
 
     if let Ok(lib_dir) = lib_dir {
@@ -148,6 +144,19 @@ fn configured_by_vcpkg() -> bool {
 #[cfg(not(target_env = "msvc"))]
 fn configured_by_vcpkg() -> bool {
     false
+}
+
+fn use_general_lib_dir() -> Result<String, VarError>{
+    println!("cargo:rerun-if-env-changed=PQ_LIB_DIR");
+    println!("PQ_LIB_DIR = {:?}", env::var("PQ_LIB_DIR"));
+
+    let pq_lib_dir = env::var("PQ_LIB_DIR");
+    if let Ok(pg_lib_path) = pq_lib_dir {
+        let path =  PathBuf::from(&pg_lib_path);
+        if !path.exists() {
+            panic!("Folder {:?} doesn't exist in the configured path: {:?}", "PQ_LIB_DIR", path);
+        }
+    }
 }
 
 fn pg_config_path() -> PathBuf {


### PR DESCRIPTION
This is achieved by using specific env_vars for the target.
This allows the crate being compiled for diesel_migrations for the host.
While also compiling it with the correct lib dir for the target.

I use this version (including the fixes of #28) of the build.rs to make cross compilation from a M1 Mac to x86_64 and it works great. 👍 