### PR TITLE
fix: added wldap32 to linked libraries for target_env msvc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -120,6 +120,7 @@ fn configured_by_vcpkg() -> bool {
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=secur32");
         println!("cargo:rustc-link-lib=shell32");
+        println!("cargo:rustc-link-lib=wldap32");
     }).is_ok()
 }
 


### PR DESCRIPTION
This crate failes during linkage on Windows using the recent libpq version (15.2) provided by vcpkg.
Looks to me like the only thing missing is adding wldap32, once I've added that everything works fine.

```
error: linking with `link.exe` failed: exit code: 1120
  |
  = note: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\MSVC\\14.35.32215\\bin\\HostX64\\x64\\link.exe" "/NOLOGO" "C:\\Users\\BamButz\\AppData\\Local
\\Temp\\rustcZlhq7w\\symbols.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.2ddyc16jldmdt8dl.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0
fb39eeb.2u8yqiuqi3icz7b.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.2vpvvjfq7is9kdps.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0
fb39eeb.30d9989cjc4xwqts.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.3kjdqege5mn08zp1.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b
0fb39eeb.40pqf0ho6wjo7ue1.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.458ncvuagslvo5xk.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2
b0fb39eeb.45ug4cyw49weejl8.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.48wmlyjc79c4s8ox.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d
2b0fb39eeb.4ekbfkehwel01wp8.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.4g97b03wg5vjbbvk.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9
d2b0fb39eeb.52w203ru6csd0apf.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.54zqngubq5nozp57.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e
9d2b0fb39eeb.5eu03dmb2ars4dm3.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.d5gfs0pq864u3t4.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e
9d2b0fb39eeb.ibvt56vv0olymmd.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.ozxrdgkkpnz3bvn.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9
d2b0fb39eeb.pk3qdl3xnh0ukfa.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.pokrkupasko2nrj.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d
2b0fb39eeb.uwhjveiauczzyz4.rcgu.o" "D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.4w1qijlv6m294nb9.rcgu.o" "/LIBPATH:D:\\Projects\\pq-sys\\target\\debug\\deps" "/L
IBPATH:D:\\Software\\vcpkg\\installed\\x64-windows-static-md\\lib" "/LIBPATH:C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-ms
vc\\lib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libtest-6c2a016a62f03e3c.rlib" "C:\\Users\\BamButz\\.rustu
p\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libgetopts-48bb9938631f3ce1.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-w
indows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libunicode_width-1a77658c715c0e3a.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\
x86_64-pc-windows-msvc\\lib\\librustc_std_workspace_std-a01563643cc25a04.rlib" "D:\\Projects\\pq-sys\\target\\debug\\deps\\libpq_sys-3911664e82af2306.rlib" "C:\\Users\\BamButz\\.rust
p\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libstd-9f65829977a28b3f.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-wind
ows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libpanic_unwind-0e317596d7fb62b4.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86
_64-pc-windows-msvc\\lib\\librustc_demangle-ab973503635148e8.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\
\libstd_detect-60b7aa0a2358b614.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libhashbrown-cd6aa41f43f53ce
3.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libminiz_oxide-88a4232a8779d8ac.rlib" "C:\\Users\\BamButz\
\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libadler-a9f9f52ac1a95cb8.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_6
4-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\librustc_std_workspace_alloc-29f32b95b7504de2.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-m
svc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libunwind-9830e462dc6b4b78.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-wind
ows-msvc\\lib\\libcfg_if-44ab97457d9c0d23.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\liblibc-71dfac72fe
747b71.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\liballoc-c459514f814b56b6.rlib" "C:\\Users\\BamButz\\
.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\librustc_std_workspace_core-77d9806000248920.rlib" "C:\\Users\\BamButz\\.rustup\\toolch
ains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libcore-9380feaa1ae51240.rlib" "C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc
\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libcompiler_builtins-a0d563049c58a24e.rlib" "kernel32.lib" "libecpg.lib" "libecpg_compat.lib" "libpgcommon.lib" "libpgport.lib" "libpgtyp
es.lib" "libpq.lib" "zlib.lib" "libcrypto.lib" "libssl.lib" "lz4.lib" "crypt32.lib" "gdi32.lib" "user32.lib" "secur32.lib" "shell32.lib" "kernel32.lib" "advapi32.lib" "userenv.lib" "
kernel32.lib" "ws2_32.lib" "bcrypt.lib" "msvcrt.lib" "legacy_stdio_definitions.lib" "/NXCOMPAT" "/LIBPATH:C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\
\rustlib\\x86_64-pc-windows-msvc\\lib" "/OUT:D:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d2b0fb39eeb.exe" "/OPT:REF,NOICF" "/DEBUG" "/NATVIS:C:\\Users\\BamButz\\.rustup\\to
olchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\intrinsic.natvis" "/NATVIS:C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\liba
lloc.natvis" "/NATVIS:C:\\Users\\BamButz\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libcore.natvis" "/NATVIS:C:\\Users\\BamButz\\.rustup\\toolchains\\sta
ble-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libstd.natvis"
  = note: Non-UTF-8 output: libpq.lib(fe-connect.obj) : error LNK2019: Verweis auf nicht aufgel\x94stes externes Symbol \"__imp_ldap_connect\" in Funktion \"ldapServiceLookup\".\r\nl
ibpq.lib(fe-connect.obj) : error LNK2019: Verweis auf nicht aufgel\x94stes externes Symbol \"__imp_ldap_init\" in Funktion \"ldapServiceLookup\".\r\nlibpq.lib(fe-connect.obj) : error
 LNK2019: Verweis auf nicht aufgel\x94stes externes Symbol \"__imp_ldap_unbind\" in Funktion \"ldapServiceLookup\".\r\nlibpq.lib(fe-connect.obj) : error LNK2019: Verweis auf nicht au
fgel\x94stes externes Symbol \"__imp_ldap_search_st\" in Funktion \"ldapServiceLookup\".\r\nlibpq.lib(fe-connect.obj) : error LNK2019: Verweis auf nicht aufgel\x94stes externes Symbo
l \"__imp_ldap_msgfree\" in Funktion \"ldapServiceLookup\".\r\nlibpq.lib(fe-connect.obj) : error LNK2019: Verweis auf nicht aufgel\x94stes externes Symbol \"__imp_ldap_err2string\" i
n Funktion \"ldapServiceLookup\".\r\nlibpq.lib(fe-connect.obj) : error LNK2019: Verweis auf nicht aufgel\x94stes externes Symbol \"__imp_ldap_first_entry\" in Funktion \"ldapServiceL
ookup\".\r\nlibpq.lib(fe-connect.obj) : error LNK2019: Verweis auf nicht aufgel\x94stes externes Symbol \"__imp_ldap_count_entries\" in Funktion \"ldapServiceLookup\".\r\nlibpq.lib(f
e-connect.obj) : error LNK2019: Verweis auf nicht aufgel\x94stes externes Symbol \"__imp_ldap_get_values_len\" in Funktion \"ldapServiceLookup\".\r\nlibpq.lib(fe-connect.obj) : error
 LNK2019: Verweis auf nicht aufgel\x94stes externes Symbol \"__imp_ldap_value_free_len\" in Funktion \"ldapServiceLookup\".\r\nD:\\Projects\\pq-sys\\target\\debug\\deps\\smoke-c87e9d
2b0fb39eeb.exe : fatal error LNK1120: 10 nicht aufgel\x94ste Externe\r\n

error: could not compile `pq-sys` due to previous error

```