### PR TITLE
Allow other crates to reuse the bundled static build

### DIFF
--- a/pq-src/Cargo.toml
+++ b/pq-src/Cargo.toml
@@ -17,6 +17,7 @@ include = [
 description = "Bundled version of libpq"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sgrif/pq-sys"
+links = "pq_sys_src"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pq-src/build.rs
+++ b/pq-src/build.rs
@@ -220,15 +220,15 @@ fn main() {
 
     basic_build
         .clone()
-        .files(LIBPORTS.iter().map(|p| format!("{path}{port_path}{p}")))
-        .compile("ports");
-
-    basic_build
-        .clone()
-        .files(LIBCOMMON.iter().map(|p| format!("{path}{common_path}{p}")))
-        .compile("pgcommon");
-
-    basic_build
-        .files(LIBPQ.iter().map(|p| format!("{path}{pq_path}{p}")))
+        .files(
+            LIBPORTS
+                .iter()
+                .map(|p| format!("{path}{port_path}{p}"))
+                .chain(LIBCOMMON.iter().map(|p| format!("{path}{common_path}{p}")))
+                .chain(LIBPQ.iter().map(|p| format!("{path}{pq_path}{p}"))),
+        )
         .compile("pq");
+
+    println!("cargo:include={path}/src/include");
+    println!("cargo:lib_dir={}", std::env::var("OUT_DIR").expect("Set by cargo"));
 }

--- a/pq-src/build.rs
+++ b/pq-src/build.rs
@@ -229,6 +229,48 @@ fn main() {
         )
         .compile("pq");
 
-    println!("cargo:include={path}/src/include");
-    println!("cargo:lib_dir={}", std::env::var("OUT_DIR").expect("Set by cargo"));
+    let out = std::env::var("OUT_DIR").expect("Set by cargo");
+    let include_path = PathBuf::from(&out).join("include");
+    let lib_pq_path = PathBuf::from(format!("{path}/{pq_path}"));
+    std::fs::create_dir_all(&include_path).expect("Failed to create include directory");
+    std::fs::create_dir_all(include_path.join("postgres").join("internal"))
+        .expect("Failed to create include directory");
+    std::fs::copy(
+        lib_pq_path.join("libpq-fe.h"),
+        include_path.join("libpq-fe.h"),
+    )
+    .expect("Copying headers failed");
+    std::fs::copy(
+        lib_pq_path.join("libpq-events.h"),
+        include_path.join("libpq-events.h"),
+    )
+    .expect("Copying headers failed");
+
+    std::fs::copy(
+        lib_pq_path.join("libpq-int.h"),
+        include_path
+            .join("postgres")
+            .join("internal")
+            .join("libpq-int.h"),
+    )
+    .expect("Copying headers failed");
+    std::fs::copy(
+        lib_pq_path.join("fe-auth-sasl.h"),
+        include_path
+            .join("postgres")
+            .join("internal")
+            .join("fe-auth-sasl.h"),
+    )
+    .expect("Copying headers failed");
+    std::fs::copy(
+        lib_pq_path.join("pqexpbuffer.h"),
+        include_path
+            .join("postgres")
+            .join("internal")
+            .join("pqexpbuffer.h"),
+    )
+    .expect("Copying headers failed");
+
+    println!("cargo:include={out}/include");
+    println!("cargo:lib_dir={}", out);
 }


### PR DESCRIPTION
This commit sets the `DEP_PQ_SYS_SRC_INCLUDE` and
`DEP_PQ_SYS_SRC_LIB_DIR` enviroment variable so that other crates can reuse the static build.