### PR TITLE
Make usage of openSSL optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-2019]
-        features: [default, bundled, buildtime_bindgen]
+        features: [default, bundled, bundled_without_openssl, buildtime_bindgen]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -44,7 +44,7 @@ jobs:
           sudo service postgresql restart && sleep 3
 
       - name: Install postgres (MacOS)
-        if: matrix.os == 'macos-13' && matrix.features != 'bundled'
+        if: matrix.os == 'macos-13' && matrix.features != 'bundled' && matrix.features != 'bundled_without_openssl'
         run: |
           brew install postgresql
           brew services start postgresql@14
@@ -52,7 +52,7 @@ jobs:
           createuser -s postgres
 
       - name: Install postgres  (MacOS M1)
-        if: matrix.os == 'macos-14' && matrix.features != 'bundled'
+        if: matrix.os == 'macos-14' && matrix.features != 'bundled' && matrix.features != 'bundled_without_openssl'
         run: |
           brew install postgresql
           brew services start postgresql@14
@@ -60,7 +60,7 @@ jobs:
           createuser -s postgres
 
       - name: Install postgres (Windows)
-        if: runner.os == 'Windows' && matrix.features != 'bundled'
+        if: runner.os == 'Windows' && matrix.features != 'bundled' && matrix.features != 'bundled_without_openssl'
         shell: bash
         run: |
           choco install postgresql12 --force --params '/Password:root'
@@ -73,6 +73,18 @@ jobs:
         run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV
           vcpkg install openssl:x64-windows-static-md
+
+      - name: Remove openssl (Linux, bundled_without_openssl)
+        if: runner.os == 'Linux' && matrix.features == 'bundled_without_openssl'
+        run: sudo apt-get remove -y libssl-dev
+
+      - name: Remove openssl (MacOS, bundled_without_openssl)
+        if: matrix.os == 'macos-13' && matrix.features == 'bundled_without_openssl'
+        run: brew uninstall openssl@1.1
+
+      - name: Remove openssl (MacOS M1, bundled_without_openssl)
+        if: matrix.os == 'macos-14' && matrix.features == 'bundled_without_openssl'
+        run: brew uninstall openssl@1.1
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Changed
+
+* `openssl` usage can now be disabled with the `bundled_without_openssl` feature of `pq-sys`.
+  To deactivate `openssl`, enable it:
+  ```toml
+  [dependencies]
+  pq-sys = { version = "0.3.0", features = ["bundled_without_openssl"]}
+  ```
+
 ## pq-sys [0.6.1] 2024-06-11
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = ["pq-src"]
 name = "pq_sys"
 
 [dependencies]
-pq-src = { path = "pq-src", version = ">=0.2, <0.4", optional = true }
+pq-src = { path = "pq-src", version = ">=0.2, <0.4", optional = true , default-features = false }
 
 [build-dependencies]
 pkg-config = { version = "0.3.0", optional = true }
@@ -25,5 +25,6 @@ vcpkg = "0.2.6"
 
 [features]
 default = []
-bundled = ["pq-src"]
+bundled = ["pq-src/with-openssl"]
+bundled_without_openssl = ["dep:pq-src"]
 buildtime_bindgen = ["dep:bindgen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ vcpkg = "0.2.6"
 
 [features]
 default = []
-bundled = ["pq-src/with-openssl"]
+bundled = ["bundled_without_openssl", "pq-src/with-openssl"]
 bundled_without_openssl = ["dep:pq-src"]
 buildtime_bindgen = ["dep:bindgen"]

--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ If pkg-config is being used, it's configuration options will apply.
 ### Features
 
 * `buildtime_bindgen`: Run `bindgen` at build-time to generate bindings using installed headers. Not compatible with the `bundled` feature.
-* `bundled`: Build the bundled version of `libpq` from source.
-  To use a bundled version of `openssl`, add the `openssl-sys` crate with the `vendored` feature to your crate dependencies:
+* `bundled`: Build the bundled version of `libpq` from source. It will look for `openssl` installed on your system.
+  To use a bundled version of `openssl`, add the `openssl-sys` crate with the vendored feature to your crate dependencies: 
   ```toml
   [dependencies]
   openssl-sys = { version = "0.9.93", features = ["vendored"] }
   ```
+* `bundled_without_openssl`: Build the bundled version of `libpq` from source without `openssl`. This disables the TLS support in `libpq`, so that you cannot connect to a database requiring TLS anymore.
 
 ## FAQ
 

--- a/build.rs
+++ b/build.rs
@@ -80,10 +80,12 @@ impl Display for LinkingOptions {
 }
 
 fn main() {
-    if cfg!(feature = "bundled") && cfg!(feature = "buildtime_bindgen") {
+    if (cfg!(feature = "bundled") || cfg!(feature = "bundled_without_openssl"))
+        && cfg!(feature = "buildtime_bindgen")
+    {
         panic!("Combining the `bundled` and `builtime_bindgen` feature is not supported");
     }
-    if cfg!(feature = "bundled") {
+    if cfg!(feature = "bundled") || cfg!(feature = "bundled_without_openssl") {
         // everything else is handled
         // by pq-src
         return;

--- a/pq-src/Cargo.toml
+++ b/pq-src/Cargo.toml
@@ -23,11 +23,12 @@ categories = ["database", "external-ffi-bindings"]
 readme = "README.md"
 
 [dependencies]
-openssl-sys = "0.9.93"
+openssl-sys = { version = "0.9.93", optional = true }
 
 [build-dependencies]
 cc = "1.0.83"
 
 [features]
-default = []
+default = ["with-openssl"]
 with-asan = []
+with-openssl = ["dep:openssl-sys"]

--- a/pq-src/additional_include/pg_config.h
+++ b/pq-src/additional_include/pg_config.h
@@ -11,7 +11,11 @@
 #define BLCKSZ 8192
 
 /* Saved arguments from configure */
+#if defined USE_OPENSSL
 #define CONFIGURE_ARGS " '--with-openssl' '--without-readline'"
+#else
+#define CONFIGURE_ARGS " '--without-readline'"
+#endif
 
 /* Define to the default TCP port number on which the server listens and to
    which clients will try to connect. This can be overridden at run-time, but
@@ -211,9 +215,6 @@
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
-
-/* Define to 1 to build with OpenSSL support. (--with-ssl=openssl) */
-#define USE_OPENSSL 1
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/pq-src/build.rs
+++ b/pq-src/build.rs
@@ -79,10 +79,15 @@ const LIBCOMMON_BASE: &[&str] = &[
     "restricted_token.c",
     "sprompt.c",
     "logging.c",
+];
+
+const LIBCOMMON_OPENSSL: &[&str] = &[
     "cryptohash_openssl.c",
     "hmac_openssl.c",
     "protocol_openssl.c",
 ];
+
+const LIBCOMMON_NOT_OPENSSL: &[&str] = &["cryptohash.c", "hmac.c", "md5.c", "sha1.c", "sha2.c"];
 
 const LIBCOMMON_NOT_WINDOWS: &[&str] = &[];
 
@@ -102,9 +107,9 @@ const LIBPQ_BASE: &[&str] = &[
     "legacy-pqsignal.c",
     "libpq-events.c",
     "pqexpbuffer.c",
-    "fe-secure-common.c",
-    "fe-secure-openssl.c",
 ];
+
+const LIBPQ_OPENSSL: &[&str] = &["fe-secure-common.c", "fe-secure-openssl.c"];
 
 const LIBPQ_NOT_WINDOWS: &[&str] = &[];
 
@@ -120,6 +125,7 @@ fn unimplemented() -> ! {
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let use_openssl = env::var("CARGO_FEATURE_WITH_OPENSSL").is_ok();
 
     println!("cargo:rerun-if-changed=additional_include");
     let crate_dir = env!("CARGO_MANIFEST_DIR");
@@ -168,10 +174,9 @@ fn main() {
         format!("{path}src/include"),
         format!("{crate_dir}/additional_include"),
         temp_include.clone(),
-        env::var("DEP_OPENSSL_INCLUDE").unwrap().clone(),
     ][..];
 
-    let includes = if target_os == "windows" {
+    let mut includes = if target_os == "windows" {
         let includes_windows = &[
             format!("{path}/src/include/port/win32/"),
             format!("{path}/src/include/port/win32_msvc/"),
@@ -180,6 +185,10 @@ fn main() {
     } else {
         base_includes.to_vec()
     };
+
+    if use_openssl {
+        includes.extend_from_slice(&[env::var("DEP_OPENSSL_INCLUDE").unwrap().clone()]);
+    }
 
     basic_build
         .define("FRONTEND", None)
@@ -212,9 +221,23 @@ fn main() {
         _ => unimplemented(),
     };
 
+    let (libcommon, libpq) = if use_openssl {
+        // Define to 1 to build with OpenSSL support. (--with-ssl=openssl)
+        basic_build.define("USE_OPENSSL", "1");
+        (
+            [LIBCOMMON_BASE, LIBCOMMON_OPENSSL].concat(),
+            [LIBPQ_BASE, LIBPQ_OPENSSL].concat(),
+        )
+    } else {
+        (
+            [LIBCOMMON_BASE, LIBCOMMON_NOT_OPENSSL].concat(),
+            LIBPQ_BASE.to_vec(),
+        )
+    };
+
     let libports = LIBPORTS_BASE.iter().chain(libports_os);
-    let libcommon = LIBCOMMON_BASE.iter().chain(libcommon_os);
-    let libpq = LIBPQ_BASE.iter().chain(libpq_os);
+    let libcommon = libcommon.iter().chain(libcommon_os);
+    let libpq = libpq.iter().chain(libpq_os);
 
     basic_build
         .files(

--- a/pq-src/build.rs
+++ b/pq-src/build.rs
@@ -187,7 +187,7 @@ fn main() {
     };
 
     if use_openssl {
-        includes.extend_from_slice(&[env::var("DEP_OPENSSL_INCLUDE").unwrap().clone()]);
+        includes.push(env::var("DEP_OPENSSL_INCLUDE").unwrap());
     }
 
     basic_build

--- a/pq-src/src/lib.rs
+++ b/pq-src/src/lib.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "with-openssl")]
 extern crate openssl_sys;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,7 +1,9 @@
 extern crate pq_sys;
 
+#[cfg(not(feature = "bundled_without_openssl"))]
 #[test]
-fn test_ssl_init()
-{
-    unsafe{pq_sys::PQinitSSL(1);}
+fn test_ssl_init() {
+    unsafe {
+        pq_sys::PQinitSSL(1);
+    }
 }


### PR DESCRIPTION
Add the possibility to disable the usage of `openssl` when building `libpq` from source.