### PR TITLE
Fix linker error when building without openssl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "bundled")]
+#[cfg(any(feature = "bundled", feature = "bundled_without_openssl"))]
 extern crate pq_src;
 
 #[cfg(not(feature = "buildtime_bindgen"))]


### PR DESCRIPTION
Since https://github.com/sgrif/pq-sys/pull/66 the [job testing the compilation with `diesel` failed](https://github.com/sgrif/pq-sys/actions/runs/10778620262/job/29890364777#step:16:176) because of a missing `extern crate` in `pq-sys`. 
The CI passed just fine because the `diesel` job is allowed to failed, so I missed that.