### PR TITLE
Bump libpq source files to 17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### pq-src [0.3.5] 2025-03-17
+
+* Update the bundled libpq version to 17.4
+
 ### pq-src [0.3.4] 2025-03-03
 
 * Include three missing header files for the without openssl configuration

--- a/pq-src/Cargo.toml
+++ b/pq-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pq-src"
-version = "0.3.4"
+version = "0.3.5+libpq-17.4"
 edition = "2021"
 include = [
         "src/**/*.rs",


### PR DESCRIPTION
This commit updates the libpq source files to the postgres 17.4 release tag.