### PR TITLE
fix: use std::env::var instead of env! in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -114,7 +114,8 @@ fn main() {
                         outlining the details of this target");
             }
         };
-        let source_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(bindings_name);
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("Set by cargo");
+        let source_path = PathBuf::from(manifest_dir).join(bindings_name);
         std::fs::copy(source_path, out_path).expect("Couldn't write bindings");
     }
 

--- a/pq-src/build.rs
+++ b/pq-src/build.rs
@@ -169,7 +169,7 @@ fn main() {
     let use_openssl = env::var("CARGO_FEATURE_WITH_OPENSSL").is_ok();
 
     println!("cargo:rerun-if-changed=additional_include");
-    let crate_dir = env!("CARGO_MANIFEST_DIR");
+    let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let temp_include = format!("{}/more_include/", env::var("OUT_DIR").unwrap());
     let path = format!("{crate_dir}/source/");
     let port_path = "src/port/";

--- a/pq-src/build.rs
+++ b/pq-src/build.rs
@@ -169,7 +169,7 @@ fn main() {
     let use_openssl = env::var("CARGO_FEATURE_WITH_OPENSSL").is_ok();
 
     println!("cargo:rerun-if-changed=additional_include");
-    let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let crate_dir = std::env::var("CARGO_MANIFEST_DIR").expect("Set by cargo");
     let temp_include = format!("{}/more_include/", env::var("OUT_DIR").unwrap());
     let path = format!("{crate_dir}/source/");
     let port_path = "src/port/";


### PR DESCRIPTION
This defers the read of `CARGO_MANIFEST_DIR`. This should have no impact for regular Cargo builds.

The motivation is that for Bazel builds, `build.rs` may be built with a different `CARGO_MANIFEST_DIR` than when it is run, and the files are present in the latter. See https://github.com/bazelbuild/rules_rust/issues/3369#issuecomment-2745903804 for discussion.

Tested with `cargo test --features=bundled_without_openssl` on a mac.